### PR TITLE
Reviewer AMC: Poll cassandra at cassandra_hostname rather than local_ip

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -35,6 +35,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 # This script polls a cassandra process and check whether it is healthy by checking
-# that the 9160 port is open.
-/usr/share/clearwater/bin/poll-tcp 9160
+# that the 9160 port is open at cassandra_hostname.
+. /etc/clearwater/config
+/usr/share/clearwater/bin/poll-tcp 9160 $cassandra_hostname
 exit $?


### PR DESCRIPTION
As promised, the follow on to https://github.com/Metaswitch/clearwater-infrastructure/pull/149.

Fixes https://github.com/Metaswitch/clearwater-cassandra/issues/22.

Tested on an AIO node.