### PR TITLE
[Reviewer: Ellie] Use Java 7 when Cassandra 2.0.14 is installed

### DIFF
--- a/debian/clearwater-cassandra.postinst
+++ b/debian/clearwater-cassandra.postinst
@@ -56,7 +56,11 @@ NAME=cassandra
 case "$1" in
     configure)
         # Make sure that Java 7 is in use
-        update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+        perl -p -i -e 's/^JAVA_HOME=.+\n//' /etc/default/cassandra
+        echo "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/" >> /etc/default/cassandra
+        perl -p -i -e 's/^JAVA_HOME=.+\n//' /usr/share/cassandra/cassandra.in.sh
+        echo "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/" >> /usr/share/cassandra/cassandra.in.sh
+
         # Set up Monit configuration for Cassandra
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-cassandra.monit /etc/monit/conf.d/
         service clearwater-infrastructure restart

--- a/debian/clearwater-cassandra.postinst
+++ b/debian/clearwater-cassandra.postinst
@@ -55,6 +55,8 @@ NAME=cassandra
 
 case "$1" in
     configure)
+        # Make sure that Java 7 is in use
+        update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
         # Set up Monit configuration for Cassandra
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-cassandra.monit /etc/monit/conf.d/
         service clearwater-infrastructure restart


### PR DESCRIPTION
I've upgraded a node from Cassandra 1.2 to 2.0, and confirmed that it comes up without further manual tweaks.