### PR TITLE
Reviewer EM: Poll 9160 on 127.0.0.1 if cassandra_hostname isn't specified

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -37,5 +37,6 @@
 # This script polls a cassandra process and check whether it is healthy by checking
 # that the 9160 port is open at cassandra_hostname.
 . /etc/clearwater/config
+[ ! -z "$cassandra_hostname" ] || cassandra_hostname="127.0.0.1"
 /usr/share/clearwater/bin/poll-tcp 9160 $cassandra_hostname
 exit $?


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-cassandra/issues/30. If we start up Cassandra without cassandra_hostname specified in etc/clearwater/config, poll_cassandra will poll local_ip but cassandra will listen on localhost. Not any more!