### PR TITLE
[Reviewer: Matt] Only poll cassandra after it's been up for 2 mins

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -34,6 +34,15 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+# Get how long the cassandra process has been running. If this is less than
+# 2 minutes, then don't poll cassandra (as it may not be up yet).
+# Getting the uptime can fail if the cassandra process fails - this is caught
+# by the monit script.
+value=$( ps -p $( cat /var/run/cassandra/cassandra.pid ) -o etimes=)
+if [ $? == 0 ] && [ "$value" -lt 1200 ]; then
+  exit 0
+fi
+
 # This script polls a cassandra process and check whether it is healthy by checking
 # that the 9160 port is open at cassandra_hostname.
 . /etc/clearwater/config

--- a/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
+++ b/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
@@ -66,11 +66,7 @@ check process cassandra_process with pidfile /var/run/cassandra/cassandra.pid
 
 # Check that cassandra is listening on 9160. This depends on the cassandra
 # process (and so won't run unless the cassandra process is running).
-#
-# Currently disabled because Cassandra doesn't boot at a reliable enough speed
-# to allow sensible monitoring.
-#
-#check program poll_cassandra with path "/usr/share/clearwater/bin/poll_cassandra.sh"
-#  group cassandra
-#  depends on cassandra_process
-#  if status != 0 for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 4000.3; /etc/init.d/cassandra stop'"
+check program poll_cassandra with path "/usr/share/clearwater/bin/poll_cassandra.sh"
+  group cassandra
+  depends on cassandra_process
+  if status != 0 for 3 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 4000.3; /etc/init.d/cassandra stop'"


### PR DESCRIPTION
Matt, can you review this change to only poll cassandra if the cassandra process has been up for 2 minutes. I've made the change in the poll_cassandra script rather than monit, as I think monit will need substantial changes to use uptime/start delay in a check program context. 

Tested live