### PR TITLE
Reviewer Ellie - Re-enable thrift if poll_cassandra fails

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -42,4 +42,9 @@
 
 [ ! -z "$cassandra_hostname" ] || cassandra_hostname="127.0.0.1"
 /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/poll-tcp 9160 $cassandra_hostname
-exit $?
+rc=$?
+if [[ $rc != 0 ]]
+then
+  nodetool enablethrift
+fi
+exit $rc


### PR DESCRIPTION
Ellie, this change restarts the thrift interface if poll_cassandra fails (as discussed).  I've tested this on the dogfood system, by running `nodetool disablethrift` and checking that it is re-enabled within 10 seconds.

I've not enabled the `poll_cassandra` monitor since that's blocked on your changes to add a post-start grace period.