### PR TITLE
[Reviewer: Ellie] Minor changes to cassandra backup/restore scripts

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/do_backup.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/do_backup.sh
@@ -74,9 +74,10 @@ do
   rm -r $BACKUP_DIR/$f
 done
 
-# Create new backup
+# Create new backup.  We remove any xss=.., as this can be printed out by
+# cassandra-env.sh.
 echo "Creating backup for keyspace $KEYSPACE..."
-nodetool -h localhost -p 7199 snapshot $KEYSPACE
+nodetool -h localhost -p 7199 snapshot $KEYSPACE | grep -v "^xss = "
 
 # Check we successfully took the snapshot by looking at the return code
 # for the nodetool command
@@ -114,7 +115,8 @@ do
 done
 
 # Finally remove the snapshots from the Cassandra data directory, leaving only
-# the backups in the backup directory
-nodetool clearsnapshot $KEYSPACE
+# the backups in the backup directory.  We remove any xss=.., as this can be
+# printed out by cassandra-env.sh.
+nodetool clearsnapshot $KEYSPACE | grep -v "^xss = "
 
 echo "Backups can be found at: $BACKUP_DIR"


### PR DESCRIPTION
Ellie, please could you take a look at this? It is just a change to suppress some "xss = " output, which comes direct from the cassandra command line tools and to update some output from the restore script to say "restore" rather than "backup". I found evidence elsewhere of just grepping out the "xss =" line printing out Java options - see Metaswitch/clearwater-etcd#106.