### PR TITLE
[Reviewer: Alex] Force cassandra.yaml refresh

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -49,9 +49,9 @@ _log = logging.getLogger("cassandra_plugin")
 
 class CassandraPlugin(SynchroniserPluginBase):
 
-    cassandra_yaml_template = "/usr/share/clearwater/cassandra/cassandra.yaml.template"
-    cassandra_yaml_file = "/etc/cassandra/cassandra.yaml"
-    cassandra_topology_file = "/etc/cassandra/cassandra-rackdc.properties"
+    CASSANDRA_YAML_TEMPLATE = "/usr/share/clearwater/cassandra/cassandra.yaml.template"
+    CASSANDRA_YAML_FILE = "/etc/cassandra/cassandra.yaml"
+    CASSANDRA_TOPOLOGY_FILE = "/etc/cassandra/cassandra-rackdc.properties"
 
     def __init__(self, params):
         self._ip = params.ip
@@ -113,7 +113,7 @@ class CassandraPlugin(SynchroniserPluginBase):
         _log.info("Cassandra seeds list is {}".format(seeds_list_str))
 
         # Read cassandra.yaml template.
-        with open(self.cassandra_yaml_template) as f:
+        with open(self.CASSANDRA_YAML_TEMPLATE) as f:
             doc = yaml.load(f)
 
         # Fill in the correct listen_address and seeds values in the yaml
@@ -154,8 +154,8 @@ class CassandraPlugin(SynchroniserPluginBase):
         contents = WARNING_HEADER + "\n" + yaml.dump(doc)
         topology = WARNING_HEADER + "\n" + "dc={}\nrack=RAC1\n".format(self._local_site)
 
-        safely_write(self.cassandra_yaml_file, contents)
-        safely_write(self.cassandra_topology_file, topology)
+        safely_write(self.CASSANDRA_YAML_FILE, contents)
+        safely_write(self.CASSANDRA_TOPOLOGY_FILE, topology)
 
         # Restart Cassandra and make sure it picks up the new list of seeds.
         _log.debug("Restarting Cassandra")

--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -73,6 +73,10 @@ class CassandraPlugin(SynchroniserPluginBase):
     def cluster_description(self):
         return "Cassandra cluster"
 
+    def on_startup(self, cluster_view):
+        if os.path.exists("/etc/clearwater/force_cassandra_yaml_refresh"):
+            self.write_new_cassandra_config(self.get_seeds(cluster_view))
+
     def on_cluster_changing(self, cluster_view):
         pass
 
@@ -87,9 +91,6 @@ class CassandraPlugin(SynchroniserPluginBase):
         pass
 
     def on_stable_cluster(self, cluster_view):
-        if os.path.exists("/etc/clearwater/force_cassandra_yaml_refresh"):
-            self.write_new_cassandra_config(self.get_seeds(cluster_view))
-
         _log.debug("Clearing Cassandra not-clustered alarm")
         self._clustering_alarm.clear()
 

--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -47,156 +47,12 @@ import ipaddress
 _log = logging.getLogger("cassandra_plugin")
 
 
-def write_new_cassandra_config(cassandra_yaml_template,
-                               cassandra_yaml_file,
-                               cassandra_topology_file,
-                               ip,
-                               seeds_list,
-                               site_name,
-                               destructive_restart=False):
-    ip_is_v6 = (ipaddress.ip_address(ip).version == 6)
-    seeds_list_str = ','.join(map(str, seeds_list))
-    _log.info("Cassandra seeds list is {}".format(seeds_list_str))
-
-    # Read cassandra.yaml template.
-    with open(cassandra_yaml_template) as f:
-        doc = yaml.load(f)
-
-    # Fill in the correct listen_address and seeds values in the yaml
-    # document.
-    doc["listen_address"] = ip
-
-    # Set the thrift listen address to the IPv4 or IPv6 loopback address
-    # as appropriate. Note we can't use 127.0.0.1 in both cases because in
-    # a pure IPv6 namespace clients will only try to connect to IPv6
-    # addresses.
-    if ip_is_v6:
-        rpc_address = '::1'
-    else:
-        rpc_address = '127.0.0.1'
-
-    doc['rpc_address'] = rpc_address
-
-    doc["seed_provider"][0]["parameters"][0]["seeds"] = seeds_list_str
-    doc["endpoint_snitch"] = "GossipingPropertyFileSnitch"
-
-    # Work out the timeout from the target_latency_us value (assuming
-    # 100000 if it isn't set)
-    get_latency_cmd = "target_latency_us=100000; . /etc/clearwater/config; echo -n $target_latency_us"
-    latency = subprocess.check_output(get_latency_cmd,
-                                      shell=True,
-                                      stderr=subprocess.STDOUT)
-
-    try:
-        # We want the timeout value to be 4/5ths the maximum acceptable time
-        # of a HTTP request (which is 5 * target latency)
-        timeout = (int(latency) / 1000) * 4
-    except ValueError:
-        timeout = 400
-
-    doc["read_request_timeout_in_ms"] = timeout
-
-    # Write back to cassandra.yaml.
-    contents = WARNING_HEADER + "\n" + yaml.dump(doc)
-    topology = WARNING_HEADER + "\n" + "dc={}\nrack=RAC1\n".format(site_name)
-
-    safely_write(cassandra_yaml_file, contents)
-    safely_write(cassandra_topology_file, topology)
-
-    # Restart Cassandra and make sure it picks up the new list of seeds.
-    _log.debug("Restarting Cassandra")
-    run_command("monit unmonitor -g cassandra")
-    run_command("service cassandra stop")
-    run_command("killall $(cat /var/lib/cassandra/cassandra.pid)", log_error=False)
-
-    if destructive_restart:
-        run_command("rm -rf /var/lib/cassandra/")
-        run_command("mkdir -m 755 /var/lib/cassandra")
-        run_command("chown -R cassandra /var/lib/cassandra")
-
-    start_cassandra()
-
-
-def get_seeds(cluster_view, ip):
-    seeds_list = []
-
-    for seed, state in cluster_view.items():
-        if (state == constants.NORMAL_ACKNOWLEDGED_CHANGE or
-            state == constants.NORMAL_CONFIG_CHANGED):
-            seeds_list.append(seed)
-
-    if len(seeds_list) == 0:
-        for seed, state in cluster_view.items():
-            if (state == constants.JOINING_ACKNOWLEDGED_CHANGE or
-                state == constants.JOINING_CONFIG_CHANGED):
-                seeds_list.append(seed)
-    return seeds_list
-
-
-def join_cassandra_cluster(cluster_view,
-                           cassandra_yaml_file,
-                           cassandra_yaml_template,
-                           cassandra_topology_file,
-                           ip,
-                           site_name):
-
-    seeds_list = get_seeds(cluster_view, ip)
-    if len(seeds_list) > 0:
-        write_new_cassandra_config(cassandra_yaml_template,
-                                   cassandra_yaml_file,
-                                   cassandra_topology_file,
-                                   ip,
-                                   seeds_list,
-                                   site_name,
-                                   destructive_restart=True)
-
-        _log.debug("Cassandra node successfully clustered")
-
-    else:
-        # Something has gone wrong - the local node should be WAITING_TO_JOIN in
-        # etcd (at the very least).
-        _log.warning("No Cassandra cluster defined in etcd - unable to join")
-        pass
-
-
-def can_contact_cassandra():
-    if os.path.exists("/var/run/cassandra/cassandra.pid"):
-        rc = run_command("/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period")
-        return (rc == 0)
-    else:
-        # Cassandra isn't even running, let alone contactable
-        return False
-
-
-def leave_cassandra_cluster(namespace=None):
-    # We need Cassandra to be running so that we can connect on port 9160 and
-    # decommission it. Check if we can connect on port 9160.
-    if not can_contact_cassandra():
-        start_cassandra()
-
-    run_command("monit unmonitor -g cassandra")
-    run_command("nodetool decommission", namespace)
-
-
-def start_cassandra():
-    cassandra_not_monitored = True
-
-    # Wait until we can connect on port 9160 - i.e. Cassandra is running.
-    while True:
-        if cassandra_not_monitored:
-            # The monit command can fail because monit is still processing
-            # the unmonitor command from before (even though it has
-            # finished unmonitoring cassandra)
-            rc = run_command("monit monitor -g cassandra")
-            cassandra_not_monitored = (rc != 0)
-        elif can_contact_cassandra():
-            break
-
-        # Sleep so we don't tight loop
-        time.sleep(1)
-
-
 class CassandraPlugin(SynchroniserPluginBase):
+
+    cassandra_yaml_template = "/usr/share/clearwater/cassandra/cassandra.yaml.template"
+    cassandra_yaml_file = "/etc/cassandra/cassandra.yaml"
+    cassandra_topology_file = "/etc/cassandra/cassandra-rackdc.properties"
+
     def __init__(self, params):
         self._ip = params.ip
         self._local_site = params.local_site
@@ -209,6 +65,8 @@ class CassandraPlugin(SynchroniserPluginBase):
         self._clustering_alarm.set()
         pdlogs.NOT_YET_CLUSTERED_ALARM.log(cluster_desc=self.cluster_description())
 
+    # Interface-defined plugin functions
+
     def key(self):
         return self._key
 
@@ -219,12 +77,7 @@ class CassandraPlugin(SynchroniserPluginBase):
         pass
 
     def on_joining_cluster(self, cluster_view):
-        join_cassandra_cluster(cluster_view,
-                               "/etc/cassandra/cassandra.yaml",
-                               "/usr/share/clearwater/cassandra/cassandra.yaml.template",
-                               "/etc/cassandra/cassandra-rackdc.properties",
-                               self._ip,
-                               self._local_site)
+        self.join_cassandra_cluster(cluster_view)
 
         if (self._ip == sorted(cluster_view.keys())[0]):
             _log.debug("Adding schemas")
@@ -235,13 +88,7 @@ class CassandraPlugin(SynchroniserPluginBase):
 
     def on_stable_cluster(self, cluster_view):
         if os.path.exists("/etc/clearwater/force_cassandra_yaml_refresh"):
-            write_new_cassandra_config("/usr/share/clearwater/cassandra/cassandra.yaml.template",
-                                       "/etc/cassandra/cassandra.yaml",
-                                       "/etc/cassandra/cassandra-rackdc.properties",
-                                       self._ip,
-                                       get_seeds(cluster_view, self._ip),
-                                       self._local_site)
-            os.remove("/etc/clearwater/force_cassandra_yaml_refresh")
+            self.write_new_cassandra_config(self.get_seeds(cluster_view, self._ip))
 
         _log.debug("Clearing Cassandra not-clustered alarm")
         self._clustering_alarm.clear()
@@ -251,11 +98,140 @@ class CassandraPlugin(SynchroniserPluginBase):
             'cluster-manager',
             alarm_constants.CASSANDRA_NOT_YET_DECOMMISSIONED)
         decommission_alarm.set()
-        leave_cassandra_cluster(self._sig_namespace)
+        self.leave_cassandra_cluster()
         decommission_alarm.clear()
 
     def files(self):
         return ["/etc/cassandra/cassandra.yaml"]
+
+    # Specific methods for handling Cassandra
+
+    def write_new_cassandra_config(self, seeds_list, destructive_restart=False):
+        ip_is_v6 = (ipaddress.ip_address(self._ip).version == 6)
+        seeds_list_str = ','.join(map(str, seeds_list))
+        _log.info("Cassandra seeds list is {}".format(seeds_list_str))
+
+        # Read cassandra.yaml template.
+        with open(self.cassandra_yaml_template) as f:
+            doc = yaml.load(f)
+
+        # Fill in the correct listen_address and seeds values in the yaml
+        # document.
+        doc["listen_address"] = self._ip
+
+        # Set the thrift listen address to the IPv4 or IPv6 loopback address
+        # as appropriate. Note we can't use 127.0.0.1 in both cases because in
+        # a pure IPv6 namespace clients will only try to connect to IPv6
+        # addresses.
+        if ip_is_v6:
+            rpc_address = '::1'
+        else:
+            rpc_address = '127.0.0.1'
+
+        doc['rpc_address'] = rpc_address
+
+        doc["seed_provider"][0]["parameters"][0]["seeds"] = seeds_list_str
+        doc["endpoint_snitch"] = "GossipingPropertyFileSnitch"
+
+        # Work out the timeout from the target_latency_us value (assuming
+        # 100000 if it isn't set)
+        get_latency_cmd = "target_latency_us=100000; . /etc/clearwater/config; echo -n $target_latency_us"
+        latency = subprocess.check_output(get_latency_cmd,
+                                          shell=True,
+                                          stderr=subprocess.STDOUT)
+
+        try:
+            # We want the timeout value to be 4/5ths the maximum acceptable time
+            # of a HTTP request (which is 5 * target latency)
+            timeout = (int(latency) / 1000) * 4
+        except ValueError:
+            timeout = 400
+
+        doc["read_request_timeout_in_ms"] = timeout
+
+        # Write back to cassandra.yaml.
+        contents = WARNING_HEADER + "\n" + yaml.dump(doc)
+        topology = WARNING_HEADER + "\n" + "dc={}\nrack=RAC1\n".format(self._local_site)
+
+        safely_write(self.cassandra_yaml_file, contents)
+        safely_write(self.cassandra_topology_file, topology)
+
+        # Restart Cassandra and make sure it picks up the new list of seeds.
+        _log.debug("Restarting Cassandra")
+        run_command("monit unmonitor -g cassandra")
+        run_command("service cassandra stop")
+        run_command("killall $(cat /var/lib/cassandra/cassandra.pid)", log_error=False)
+
+        if destructive_restart:
+            run_command("rm -rf /var/lib/cassandra/")
+            run_command("mkdir -m 755 /var/lib/cassandra")
+            run_command("chown -R cassandra /var/lib/cassandra")
+
+        self.start_cassandra()
+        os.remove("/etc/clearwater/force_cassandra_yaml_refresh")
+
+    def get_seeds(self, cluster_view):
+        seeds_list = []
+
+        for seed, state in cluster_view.items():
+            if (state == constants.NORMAL_ACKNOWLEDGED_CHANGE or
+                state == constants.NORMAL_CONFIG_CHANGED):
+                seeds_list.append(seed)
+
+        if len(seeds_list) == 0:
+            for seed, state in cluster_view.items():
+                if (state == constants.JOINING_ACKNOWLEDGED_CHANGE or
+                    state == constants.JOINING_CONFIG_CHANGED):
+                    seeds_list.append(seed)
+        return seeds_list
+
+    def join_cassandra_cluster(self, cluster_view):
+        seeds_list = self.get_seeds(cluster_view)
+        if len(seeds_list) > 0:
+            self.write_new_cassandra_config(seeds_list,
+                                            destructive_restart=True)
+
+            _log.debug("Cassandra node successfully clustered")
+
+        else:
+            # Something has gone wrong - the local node should be WAITING_TO_JOIN in
+            # etcd (at the very least).
+            _log.warning("No Cassandra cluster defined in etcd - unable to join")
+            pass
+
+    def can_contact_cassandra(self):
+        if os.path.exists("/var/run/cassandra/cassandra.pid"):
+            rc = run_command("/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period")
+            return (rc == 0)
+        else:
+            # Cassandra isn't even running, let alone contactable
+            return False
+
+    def leave_cassandra_cluster(self):
+        # We need Cassandra to be running so that we can connect on port 9160 and
+        # decommission it. Check if we can connect on port 9160.
+        if not self.can_contact_cassandra():
+            self.start_cassandra()
+
+        run_command("monit unmonitor -g cassandra")
+        run_command("nodetool decommission", self._sig_namespace)
+
+    def start_cassandra(self):
+        cassandra_not_monitored = True
+
+        # Wait until we can connect on port 9160 - i.e. Cassandra is running.
+        while True:
+            if cassandra_not_monitored:
+                # The monit command can fail because monit is still processing
+                # the unmonitor command from before (even though it has
+                # finished unmonitoring cassandra)
+                rc = run_command("monit monitor -g cassandra")
+                cassandra_not_monitored = (rc != 0)
+            elif self.can_contact_cassandra():
+                break
+
+            # Sleep so we don't tight loop
+            time.sleep(1)
 
 
 def load_as_plugin(params):

--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -88,7 +88,7 @@ class CassandraPlugin(SynchroniserPluginBase):
 
     def on_stable_cluster(self, cluster_view):
         if os.path.exists("/etc/clearwater/force_cassandra_yaml_refresh"):
-            self.write_new_cassandra_config(self.get_seeds(cluster_view, self._ip))
+            self.write_new_cassandra_config(self.get_seeds(cluster_view))
 
         _log.debug("Clearing Cassandra not-clustered alarm")
         self._clustering_alarm.clear()

--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -234,6 +234,10 @@ class CassandraPlugin(SynchroniserPluginBase):
             # Sleep so we don't tight loop
             time.sleep(1)
 
+        # Restart clearwater-infrastructure so any necessary schema creation
+        # scripts get run
+        run_command("sudo service clearwater-infrastructure restart")
+
 
 def load_as_plugin(params):
     return CassandraPlugin(params)

--- a/debian/clearwater-cassandra.postinst
+++ b/debian/clearwater-cassandra.postinst
@@ -65,9 +65,9 @@ case "$1" in
         service clearwater-infrastructure restart
         reload clearwater-monit || true
 
-        # Stop Cassandra so that Monit restarts it, with any of the
-        # configuration files we've changed in place
-        service cassandra stop
+        # Force the clustering plugin to regenerate our cassandra.yaml, so that
+        # changes to the template are picked up
+        touch "/etc/clearwater/force_cassandra_yaml_refresh"
 
         # Stop the cluster manager, so that it is restarted by Monit and picks
         # up the new Cassandra scaling plugins. We check whether the process is
@@ -76,6 +76,8 @@ case "$1" in
           service clearwater-cluster-manager stop || /bin/true
         fi
 
+        # No need to restart Cassandra - the clustering plugin will do that
+        # when it regenerates cassandra.yaml
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
This changes the Cassandra clustering plugin, so that if it's in stable state and /etc/clearwater/force_cassandra_yaml_refresh exists, it will regenerate cassandra.yaml and restart Cassandra (but not delete all the data). This'll be useful if a new clearwater-cassandra version has changed the template, for example.

I've tested by upgrading a Homer node and verifying that cassandra.yaml was put into place.

Commit-by-commit review might be sensible - the first commit is a minimal rework to do this, but that meant factoring out a `write_new_cassandra_config` method with a silly number of parameters, so I've then refactored it to make that a member function.
