### PR TITLE
[Reviewer: None] Cope with Monit restrictions

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
+++ b/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
@@ -60,7 +60,7 @@ check process cassandra_process with pidfile /var/run/cassandra/cassandra.pid
 #  if status != 0 then alert
 
 # Clear any alarms if the process has been running long enough.
-check program cassandra_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/cassandra/cassandra.pid monit 4000.1"
+check program cassandra_uptime with path /usr/share/clearwater/infrastructure/scripts/check-cassandra-uptime
   group cassandra
   depends on cassandra_process
   every 3 cycles

--- a/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/check-cassandra-uptime
+++ b/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/check-cassandra-uptime
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# @file check-cassandra-uptime
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# Monit 5.8.1 does not support passing arguments to check program scripts.
+# check-uptime provides common uptime-checking code. This wrapper script
+# uses it, and can be called with no arguments.
+/usr/share/clearwater/bin/check-uptime /var/run/cassandra/cassandra.pid monit 4000.1


### PR DESCRIPTION
Monit can't pass arguments to check-program scripts in its current version.