### PR TITLE
Reviewer RKD: Allow configurable replication factor

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/cassandra_schema_utils.sh
+++ b/clearwater-cassandra/usr/share/clearwater/cassandra_schema_utils.sh
@@ -34,9 +34,13 @@
 
 . /etc/clearwater/config
 
+# The default replication factor is 2, but the calling script may have other
+# ideas.
+replication_factor=${replication_factor:-2}
+
 # Create the common REPLICATION string to be used when creating Clearwater
 # Cassandra schemas. This file gets dotted in by the schema creation scripts.
-replication_str="{'class': 'SimpleStrategy', 'replication_factor': 2}"
+replication_str="{'class': 'SimpleStrategy', 'replication_factor': $replication_factor}"
 
 # If local_site_name and remote_site_names are set then this is a GR
 # deployment. Set the replication strategy to NetworkTopologyStrategy and
@@ -44,11 +48,10 @@ replication_str="{'class': 'SimpleStrategy', 'replication_factor': 2}"
 if [ -n "$local_site_name" ] && [ -n "$remote_site_names" ]
 then
   IFS=',' read -a remote_site_names_array <<< "$remote_site_names"
-  replication_str="{'class': 'NetworkTopologyStrategy', '$local_site_name': 2"
+  replication_str="{'class': 'NetworkTopologyStrategy', '$local_site_name': $replication_factor"
   for remote_site in "${remote_site_names_array[@]}"
   do
-    # Set the replication factor for each site to 2.
-    replication_str+=", '$remote_site': 2"
+    replication_str+=", '$remote_site': $replication_factor"
   done
   replication_str+="}"
 fi


### PR DESCRIPTION
We may wish to have a replication factor that isn't 2. This change allows that.

Tested by calling this script from another bash script like below and inspecting the output.

```
. clearwater-cassandra/usr/share/clearwater/cassandra_schema_utils.sh
echo $replication_str

replication_factor=3
. clearwater-cassandra/usr/share/clearwater/cassandra_schema_utils.sh
echo $replication_str
```