### PR TITLE
[Reviewer: MIRW] Fix up Cassandra script to use new is-address-ipv6 job

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra
+++ b/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra
@@ -46,7 +46,7 @@ new_file=$(mktemp)
 # IPv4 addresses (otherwise cassandra won't be able to start). This is
 # controlled via the preferIPv4Stack option in cassandra-env.sh.
 
-if ! /usr/share/clearwater/bin/is_address_ipv6.py $local_ip
+if ! /usr/share/clearwater/bin/is-address-ipv6 $local_ip
 then
   TEMPLATE_IPV4_SECTION='JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"'
 fi


### PR DESCRIPTION
Replace an old reference to the script "is_address_ipv6.py" with a reference to the new job "is-address-ipv6".

I hit this after installing http://vm-images.cw-ngv.com/cw-aio.ova (image dated 6/29/2016, 4:30:52 PM) on VirtualBox.  This was preventing Cassandra from starting, which had knock-on effects that prevented other components from starting or working correctly (e.g. I couldn't provision through Ellis).

I manually patched this one file on my cw-aio VM, and this allowed Cassandra (and everything else) to start normally.  I have not done any other testing (e.g. UTs, etc.).
