### PR TITLE
[Reviewer: AJH] Alter Cassandra configuration to listen everywhere

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra.yaml.template
+++ b/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra.yaml.template
@@ -346,7 +346,7 @@ start_rpc: true
 # that rely on node auto-discovery.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+rpc_address: 0.0.0.0
 # port for Thrift to listen for clients on
 rpc_port: 9160
 

--- a/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
+++ b/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py
@@ -126,13 +126,13 @@ class CassandraPlugin(SynchroniserPluginBase):
         doc["listen_address"] = self._ip
 
         # Set the thrift listen address to the IPv4 or IPv6 loopback address
-        # as appropriate. Note we can't use 127.0.0.1 in both cases because in
+        # as appropriate. Note we can't use 0.0.0.0 in both cases because in
         # a pure IPv6 namespace clients will only try to connect to IPv6
-        # addresses.
+        # addresses. Ideally, we'd listen on both addresses.
         if ip_is_v6:
-            rpc_address = '::1'
+            rpc_address = '::0'
         else:
-            rpc_address = '127.0.0.1'
+            rpc_address = '0.0.0.0'
 
         doc['rpc_address'] = rpc_address
 


### PR DESCRIPTION
We'd like Cassandra to listen on all addresses so that it can be used remotely.

I've left the code to listen differently if it think it's running on an IPv6 network versus an IPv4 network, but I *think* that this might be unnecessary. I've tested that this works on an IPv4 deployment spun up in Amazon, but I haven't checked that it works on a IPv6 network.
