### PR TITLE
[Reviewer: Richard] Listen on IPv6 ANY address

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra-env.sh.template
+++ b/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra-env.sh.template
@@ -248,12 +248,6 @@ fi
 # uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
 # JVM_OPTS="$JVM_OPTS -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1414"
 
-# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
-# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
-# comment out this entry to enable IPv6 support).
-<<<TEMPLATE_IPV4_SECTION>>>
-
-
 # jmx: metrics and administration interface
 #
 # add this if you're having trouble connecting:

--- a/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra.yaml.template
+++ b/clearwater-cassandra/usr/share/clearwater/cassandra/cassandra.yaml.template
@@ -346,7 +346,7 @@ start_rpc: true
 # that rely on node auto-discovery.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: 0.0.0.0
+rpc_address: ::0
 # port for Thrift to listen for clients on
 rpc_port: 9160
 

--- a/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra
+++ b/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra
@@ -42,15 +42,6 @@ TEMPLATE_HEAPSIZE_SECTION=""
 TEMPLATE_FILE=/usr/share/clearwater/cassandra/cassandra-env.sh.template
 new_file=$(mktemp)
 
-# If we're using IPv6 addresses we shouldn't tell the JVM to prefer
-# IPv4 addresses (otherwise cassandra won't be able to start). This is
-# controlled via the preferIPv4Stack option in cassandra-env.sh.
-
-if ! /usr/share/clearwater/bin/is-address-ipv6 $local_ip
-then
-  TEMPLATE_IPV4_SECTION='JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"'
-fi
-
 # On AIO nodes and in containers, we want to restrict Cassandra's memory usage,
 # as the system is shared with more processes, and Cassandra's approach of
 # using 70% of RAM isn't appropriate.
@@ -61,7 +52,6 @@ then
 fi
 
 cat $TEMPLATE_FILE |\
-  sed "s/<<<TEMPLATE_IPV4_SECTION>>>/$TEMPLATE_IPV4_SECTION/" |\
   sed "s/<<<TEMPLATE_HEAPSIZE_SECTION>>>/$TEMPLATE_HEAPSIZE_SECTION/"\
   > $new_file
 


### PR DESCRIPTION
Merging https://github.com/Metaswitch/clearwater-infrastructure/pull/369 exposed an interesting new IPv6-ish bug, which caused the Homer staging node to start failing.

We had `cassandra_hostname=localhost` set in shared_config. This meant that after https://github.com/Metaswitch/clearwater-infrastructure/pull/369 went in, poll-cassandra started trying to connect to ::1 not 127.0.0.1. Cassandra was listening on 0.0.0.0, so anything trying to reach ::1 couldn't connect.

It looks like just binding to the IPv6 ANY address, ::, works. I've tested by applying this config and running:

```
/usr/share/clearwater/bin/poll-tcp 9160 127.0.0.1; echo $?
/usr/share/clearwater/bin/poll-tcp 9160 ::1; echo $?
/usr/share/clearwater/bin/poll-tcp 9160 localhost; echo $?
/usr/share/clearwater/bin/poll-tcp 9160 10.0.0.138; echo $?
```

They all work.

Tagging @graemerobertson , @sathiyan-sivathas for interest.