### PR TITLE
[Reviewer: Seb] Run nodetool commands in the signalling namespace

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -60,6 +60,6 @@ fi
 rc=$?
 if [[ $rc != 0 ]]
 then
-  nodetool enablethrift
+  /usr/share/clearwater/bin/run-in-signaling-namespace nodetool enablethrift
 fi
 exit $rc

--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -40,6 +40,8 @@
 # Getting the uptime can fail if the cassandra process fails - this is caught
 # by the monit script.
 
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 [ $# -le 1 ] || { echo "Usage: poll_cassandra [--no-grace-period] (defaults to a two minute grace period)" >&2 ; exit 2 ; }
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
Nodetool commands should be run in the signalling namespace