### PR TITLE
[Reviewer: Seb] Add more cassandra checks

### DIFF
--- a/clearwater-cassandra/etc/init.d/cassandra.clearwater
+++ b/clearwater-cassandra/etc/init.d/cassandra.clearwater
@@ -23,9 +23,9 @@ WAIT_FOR_START=10
 CASSANDRA_HOME=/usr/share/cassandra
 FD_LIMIT=100000
 
-[ -e /usr/share/cassandra/apache-cassandra.jar ] || exit 0
-[ -e /etc/cassandra/cassandra.yaml ] || exit 0
-[ -e /etc/cassandra/cassandra-env.sh ] || exit 0
+[ -e /usr/share/cassandra/apache-cassandra.jar ] || ( echo "Exiting: apache-cassandra.jar is missing" && exit 0 )
+[ -e /etc/cassandra/cassandra.yaml ] || ( echo "Exiting: cassandra.yaml is missing" && exit 0 )
+[ -e /etc/cassandra/cassandra-env.sh ] || ( echo "Exiting: cassandra-env.sh is missing" && exit 0 )
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
@@ -77,8 +77,6 @@ do_start()
 
     [ -e `dirname "$PIDFILE"` ] || \
         install -d -ocassandra -gcassandra -m755 `dirname $PIDFILE`
-
-
 
     /usr/share/clearwater/bin/run-in-signaling-namespace start-stop-daemon -S -c cassandra -a /usr/sbin/cassandra -q -p "$PIDFILE" -t >/dev/null || return 1
 

--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cqlsh.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cqlsh.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# @file poll_cqlsh.sh
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2017  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+. /usr/share/clearwater/utils/check-root-permissions 1
+
+[ $# -le 1 ] || { echo "Usage: poll_cqlsh [--no-grace-period] (defaults to a two minute grace period)" >&2 ; exit 2 ; }
+
+# Get how long the cassandra process has been running. If this is less than
+# 2 minutes, then don't poll cqlsh (as it may not be up yet), unless
+# we're specifically asked to.
+# Getting the uptime can fail if the cassandra process fails - this is caught
+# by the monit script.
+if [ -z "$1" ]; then
+  value=$( ps -p $( cat /var/run/cassandra/cassandra.pid ) -o etimes=)
+  if [ $? == 0 ] && [ "$value" -lt 120 ]; then
+    exit 0
+  fi
+fi
+
+# This script attempts to connect to cassandra over cqlsh. This script should be
+# run in the signaling namespace if set.
+/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh -e quit
+rc=$?
+exit $rc

--- a/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
+++ b/clearwater-cassandra/usr/share/clearwater/conf/clearwater-cassandra.monit
@@ -44,7 +44,7 @@ check process cassandra_process with pidfile /var/run/cassandra/cassandra.pid
 
   # Check the service's resource usage, and stop the process if it's too high.
   # Monit will raise an alarm when it restarts the process
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 4000.3; /etc/init.d/cassandra stop'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 4000.3; start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5'"
 
 # Monitor connectivity to Cassandra ring nodes. If connectivity is lost to
 # any node issue an alarm, otherwise clear it (alarm handling is done in
@@ -72,3 +72,10 @@ check program poll_cassandra with path "/usr/share/clearwater/bin/poll_cassandra
   group cassandra
   depends on cassandra_process
   if status != 0 for 3 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 4000.3; /etc/init.d/cassandra stop'"
+
+# Check that cqlsh can connect to cassandra. This depends on the cassandra
+# process (and so won't run unless the cassandra process is running).
+check program poll_cqlsh with path "/usr/share/clearwater/bin/poll_cqlsh.sh" every 6 cycles
+  group cassandra
+  depends on cassandra_process
+  if status != 0 for 3 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 4000.3; start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5'"


### PR DESCRIPTION
This adds a stronger check that Cassandra is running (e.g. can we connect to cqlsh) that runs rarely. It also doesn't go through the init.d script to stop Cassandra (as this depends on the yaml file being present). This fixes issue #118 

Tested live