### PR TITLE
[reviewer: Ellie] Add sanity check to cassandra init file, to catch leaked processees

### DIFF
--- a/clearwater-cassandra/etc/init.d/cassandra.clearwater
+++ b/clearwater-cassandra/etc/init.d/cassandra.clearwater
@@ -101,6 +101,22 @@ do_stop()
     return $RET
 }
 
+# There should only be at most one cassandra process, and it should match
+# what we have in /var/run/cassandra/cassandra.pid.
+
+# First find the pids of potential cassandra processes
+cassandra_process_pids=$(pgrep -f CassandraDaemon)
+# Then check to see that this is being run by the cassandra user
+for pid in $cassandra_process_pids ; do
+  if (ps -u cassandra | grep $pid >/dev/null) ; then
+    # ...and that it isn't the process in the pidfile. Log and kill any leaks
+    if [ $pid -ne $(cat $PIDFILE) ] ; then
+      logger -p daemon.error -t $NAME Found leaked cassandra $pid \(correct is $(cat $PIDFILE)\) - killing $pid
+      kill -9 $pid
+    fi
+  fi
+done
+
 case "$1" in
   start)
 	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"

--- a/clearwater-cassandra/etc/init.d/cassandra.clearwater
+++ b/clearwater-cassandra/etc/init.d/cassandra.clearwater
@@ -106,10 +106,12 @@ do_stop()
 
 # First find the pids of potential cassandra processes
 cassandra_process_pids=$(pgrep -f CassandraDaemon)
-# Then check to see that this is being run by the cassandra user
+# Check that anything we find is being run by the cassandra user, so that we
+# aren't too aggressive or wide-reaching in our checks
 for pid in $cassandra_process_pids ; do
   if (ps -u cassandra | grep $pid >/dev/null) ; then
-    # ...and that it isn't the process in the pidfile. Log and kill any leaks
+    # Check the process matches the pidfile. If it doesn't we have
+    # found a leaked process. Log, and kill the leaked process.
     if [ $pid -ne $(cat $PIDFILE) ] ; then
       logger -p daemon.error -t $NAME Found leaked cassandra $pid \(correct is $(cat $PIDFILE)\) - killing $pid
       kill -9 $pid


### PR DESCRIPTION
Should fix https://github.com/Metaswitch/clearwater-cassandra/issues/126

Tested live, by modifying the value in the pidfile, running `/etc/init.d/cassandra start`, and checking that it catches and logs the 'leaked' process, and starts a new one with a pid matching the new pidfile