### PR TITLE
[No reveiewer] Add a postrm to remove plugin state files on remove and purge

### DIFF
--- a/debian/clearwater-cassandra.postrm
+++ b/debian/clearwater-cassandra.postrm
@@ -1,5 +1,41 @@
 #!/bin/sh
 
+# @file clearwater-cassandra.postrm
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# see: dh_installdeb(1)
+
 set -e
 
 case "$1" in

--- a/debian/clearwater-cassandra.postrm
+++ b/debian/clearwater-cassandra.postrm
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+  remove|purge)
+    # Remove the boostrapping state flags created by the cassandra etcd plugin:
+    rm -f /etc/cassandra/cassandra_bootstrap_in_progress
+    rm -f /etc/cassandra/cassandra_bootstrapped
+    ;;
+  *)
+    echo "postrm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
As described, this should clear out the state flags the cassandra-plugin will now put in place. 
This means that in the case of full removal and reinstall of cassandra, we should begin the clustering cycle fresh, even if we did not properly decommission before.

Testing live to see it works now.