### PR TITLE
[Reviewer: Seb] Poll Cassandra on the local IP

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/poll_cassandra.sh
@@ -52,13 +52,10 @@ if [ -z "$1" ]; then
 fi
 
 # This script polls a cassandra process and check whether it is healthy by checking
-# that the 9160 port is open at cassandra_hostname. This script should be
-# run in the signaling namespace if set.
+# that the 9160 port is open on the local IP. This script should be run in the
+# signaling namespace if set.
 
-. /etc/clearwater/config
-
-[ ! -z "$cassandra_hostname" ] || cassandra_hostname="127.0.0.1"
-/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/poll-tcp 9160 $cassandra_hostname
+/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/poll-tcp 9160
 rc=$?
 if [[ $rc != 0 ]]
 then


### PR DESCRIPTION
Cassandra now listens on all ports, and cassandra_hostname doesn't necessarily
refer to this cassandra. As such, we may end up believing Cassandra is alive because another Cassandra process is running on a different node.

This reverts the change made previously in https://github.com/Metaswitch/clearwater-issues/issues/761 - but I think this is the right think to do.

Current AIO nodes listen on 9160 on all interfaces:

```
[cw-aio]ubuntu@ec2-54-85-194-74:~$ sudo netstat -tnalp | grep java
...
tcp6       0      0 :::9160                 :::*                    LISTEN      2690/java
tcp6       0      0 127.0.0.1:9160          127.0.0.1:34028         ESTABLISHED 2690/java
...
```