### PR TITLE
[Reviewer: Krista] Get return code from cassandra schemas

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra_schemas/run_cassandra_schemas
+++ b/clearwater-cassandra/usr/share/clearwater/infrastructure/scripts/cassandra_schemas/run_cassandra_schemas
@@ -12,6 +12,9 @@ for SCHEMA in $(ls -1 /usr/share/clearwater/cassandra-schemas/* 2>/dev/null)
 do
   if [ -f "$SCHEMA" ]; then
     $SCHEMA
+    rc=$?
+    if [ $rc != 0 ]; then
+      exit $rc
+    fi
   fi
 done
-


### PR DESCRIPTION
This makes the adding schemas command exit with a non-zero return code if any schema add fails.