### PR TITLE
[Reviewer: Adam] Don't stop and start Cassandra as part of restoring a backup

### DIFF
--- a/clearwater-cassandra/usr/share/clearwater/bin/restore_backup.sh
+++ b/clearwater-cassandra/usr/share/clearwater/bin/restore_backup.sh
@@ -70,13 +70,6 @@ fi
 [ -d "$DATA_DIR/$KEYSPACE" ] || die "Keyspace $KEYSPACE does not exist" $ERROR_USER
 echo "Restoring backup for keyspace $KEYSPACE..."
 
-# Stop monit from restarting Cassandra while we restore
-monit unmonitor -g cassandra
-
-# Stop Cassandra.  We remove any xss=.., as this can be printed out by
-# cassandra-env.sh
-service cassandra stop | grep -v "^xss = "
-
 echo "Clearing commitlog..."
 rm -rf $COMMITLOG_DIR/*
 
@@ -105,7 +98,3 @@ do
   fi
 done
 
-# Start Cassandra.  We remove any xss=.., as this can be printed out by
-# cassandra-env.sh
-service cassandra start | grep -v "^xss = "
-monit monitor -g cassandra


### PR DESCRIPTION
We don't want cassandra to restart between restoring different keyspaces on the
same node, nor do we want it to restart between restoring different nodes

So we need to move the stopping and starting of Cassandra out of the backup
script

Corresponding readthedocs changes here: https://github.com/Metaswitch/clearwater-readthedocs/pull/295