### PR TITLE
Fixed Cassandra startup

### DIFF
--- a/clearwater-cassandra/etc/init.d/cassandra.clearwater
+++ b/clearwater-cassandra/etc/init.d/cassandra.clearwater
@@ -23,9 +23,9 @@ WAIT_FOR_START=10
 CASSANDRA_HOME=/usr/share/cassandra
 FD_LIMIT=100000
 
-[ -e /usr/share/cassandra/apache-cassandra.jar ] || { echo "Exiting: apache-cassandra.jar is missing" && exit 0 }
-[ -e /etc/cassandra/cassandra.yaml ] || { echo "Exiting: cassandra.yaml is missing" && exit 0 }
-[ -e /etc/cassandra/cassandra-env.sh ] || { echo "Exiting: cassandra-env.sh is missing" && exit 0 }
+[ -e /usr/share/cassandra/apache-cassandra.jar ] || { echo "Exiting: apache-cassandra.jar is missing" && exit 0; }
+[ -e /etc/cassandra/cassandra.yaml ] || { echo "Exiting: cassandra.yaml is missing" && exit 0; }
+[ -e /etc/cassandra/cassandra-env.sh ] || { echo "Exiting: cassandra-env.sh is missing" && exit 0; }
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME

--- a/clearwater-cassandra/etc/init.d/cassandra.clearwater
+++ b/clearwater-cassandra/etc/init.d/cassandra.clearwater
@@ -23,9 +23,9 @@ WAIT_FOR_START=10
 CASSANDRA_HOME=/usr/share/cassandra
 FD_LIMIT=100000
 
-[ -e /usr/share/cassandra/apache-cassandra.jar ] || ( echo "Exiting: apache-cassandra.jar is missing" && exit 0 )
-[ -e /etc/cassandra/cassandra.yaml ] || ( echo "Exiting: cassandra.yaml is missing" && exit 0 )
-[ -e /etc/cassandra/cassandra-env.sh ] || ( echo "Exiting: cassandra-env.sh is missing" && exit 0 )
+[ -e /usr/share/cassandra/apache-cassandra.jar ] || { echo "Exiting: apache-cassandra.jar is missing" && exit 0 }
+[ -e /etc/cassandra/cassandra.yaml ] || { echo "Exiting: cassandra.yaml is missing" && exit 0 }
+[ -e /etc/cassandra/cassandra-env.sh ] || { echo "Exiting: cassandra-env.sh is missing" && exit 0 }
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME


### PR DESCRIPTION
Hi Ellie, 

Could you please review this fix? SL has already reviewed this, however there was one concern he had (see bellow). 

This MR fixes an Issue with Cassandra startup - Cassandra starts when it shouldn't. The affected script checks for existence of certain files and is supposed to exit accordingly. The 'exit' command is however enclosed in parenthesis which starts a new subshell and consequently does not exit the main script.

I have tested the fix on our L3 homestead-prov deployment by temporarily removing the relevant files and checking that the script exits.

Possible concern (pointed out by SL):
Are we sure we want to exit at this point if the relevant files are missing - perhaps Cassandra is supposed to dynamically start working when those files appear, and by making it fail to start in this situation, we've just stopped it from coming up at all during VM deployment? 